### PR TITLE
chore(select): remove deprecated option includeBlank on selects

### DIFF
--- a/addon/components/validated-input.hbs
+++ b/addon/components/validated-input.hbs
@@ -50,7 +50,6 @@
     @optionLabelPath={{@optionLabelPath}}
     @optionValuePath={{@optionValuePath}}
     @optionTargetPath={{@optionTargetPath}}
-    @includeBlank={{@includeBlank}}
     @multiple={{@multiple}}
     @update={{this.update}}
     @setDirty={{this.setDirty}}

--- a/addon/components/validated-input/render.hbs
+++ b/addon/components/validated-input/render.hbs
@@ -13,7 +13,6 @@
     {{#if (eq @type "select")}}
       <this.selectComponent
         @disabled={{@disabled}}
-        @includeBlank={{@includeBlank}}
         @inputId={{@inputId}}
         @isInvalid={{@isInvalid}}
         @isValid={{@isValid}}

--- a/addon/components/validated-input/types/select.hbs
+++ b/addon/components/validated-input/types/select.hbs
@@ -23,12 +23,12 @@
   {{on "blur" this.onBlur}}
   ...attributes
 >
-  {{#if (or @prompt @includeBlank)}}
+  {{#if @prompt}}
     <option
       value=""
       disabled={{not @promptIsSelectable}}
       selected={{not @value}}
-    >{{or @prompt @includeBlank}}</option>
+    >{{@prompt}}</option>
   {{/if}}
 
   {{#if this.hasGrouping}}

--- a/addon/components/validated-input/types/select.js
+++ b/addon/components/validated-input/types/select.js
@@ -1,4 +1,3 @@
-import { deprecate } from "@ember/debug";
 import EmberObject, { action, get } from "@ember/object";
 import Component from "@glimmer/component";
 
@@ -9,24 +8,6 @@ import Component from "@glimmer/component";
  * the block syntax for options.
  */
 export default class SelectComponent extends Component {
-  constructor(...args) {
-    super(...args);
-
-    if (this.args.includeBlank) {
-      deprecate(
-        "The `includeBlank` property is deprecated. Please use `prompt` instead.",
-        false,
-        {
-          id: "ember-validated-form:NoMoreincludeBlank",
-          until: "6.0.0",
-          since: "5.1.0",
-          url: "https://github.com/adfinis/ember-validated-form/releases/tag/v5.1.0",
-          for: "ember-validated-form",
-        }
-      );
-    }
-  }
-
   get hasPreGroupedOptions() {
     return (
       this.args.options[0]?.groupName &&

--- a/tests/dummy/app/templates/docs/components/validated-input.md
+++ b/tests/dummy/app/templates/docs/components/validated-input.md
@@ -102,7 +102,6 @@ The select element also supports the following options:
 - `optionLabelPath`
 - `optionValuePath`
 - `optionTargetPath`
-- `includeBlank` (deprecated in favor of `prompt`)
 - `prompt`
 - `promptIsSelectable`
 - `groupLabelPath`

--- a/tests/dummy/app/templates/docs/migration-v6.md
+++ b/tests/dummy/app/templates/docs/migration-v6.md
@@ -1,5 +1,7 @@
 # Migration to v6
 
+## Config
+
 `ember-validated-form` is heavily based on dynamic component invokation which
 needed alot of changes in order to make it work with embroider. For the
 consumers of the addon, the only thing that changes is the static configuration.
@@ -51,3 +53,8 @@ const app = new EmberAddon(defaults, {
 As you can see above, the values in the section `defaults` changed as well.
 Previously the value was just the name of the component used as default, since
 v6 this needs to be an importable path (which allows static analysis).
+
+## Removed deprecations
+
+The `includeBlank` argument for validated inputs has been removed in favor of
+`prompt`.


### PR DESCRIPTION
BREAKING CHANGE: Remove deprecated option `includeBlank` on select inputs.