### PR TITLE
fix: scroll error into view with nested key names

### DIFF
--- a/addon/components/validated-button.js
+++ b/addon/components/validated-button.js
@@ -43,7 +43,7 @@ export default class ValidatedButtonComponent extends Component {
     if (macroCondition(getOwnConfig().scrollErrorIntoView)) {
       if (model.errors[0]?.key) {
         document
-          .querySelector(`[name=${model.errors[0].key}]`)
+          .querySelector(`[name=${model.errors[0].key.replaceAll(".", "\\.")}]`)
           ?.scrollIntoView({ behavior: "smooth" });
       }
     }

--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -48,7 +48,9 @@ export default class ValidatedFormComponent extends Component {
       if (macroCondition(getOwnConfig().scrollErrorIntoView)) {
         if (model.errors[0]?.key) {
           document
-            .querySelector(`[name=${model.errors[0].key.replaceAll(".", "\\.")}]`)
+            .querySelector(
+              `[name=${model.errors[0].key.replaceAll(".", "\\.")}]`
+            )
             ?.scrollIntoView({ behavior: "smooth" });
         }
       }

--- a/addon/components/validated-form.js
+++ b/addon/components/validated-form.js
@@ -48,7 +48,7 @@ export default class ValidatedFormComponent extends Component {
       if (macroCondition(getOwnConfig().scrollErrorIntoView)) {
         if (model.errors[0]?.key) {
           document
-            .querySelector(`[name=${model.errors[0].key}]`)
+            .querySelector(`[name=${model.errors[0].key.replaceAll(".", "\\.")}]`)
             ?.scrollIntoView({ behavior: "smooth" });
         }
       }


### PR DESCRIPTION
Hello! I ran into an error when using nested fields with the option `scrollErrorIntoView: true`

The addon code evaluates to `document.querySelector('[name=fields.nestedfield]')` and throws the following exception:
`Uncaught DOMException: Failed to execute 'querySelector' on 'Document': 'name=fields.nestedfield' is not a valid selector.`

The fix is to replace `.` with `\\.` in the query selector, i.e `document.querySelector('[name=fields\\.nestedfield]')`

Thank you!