### PR TITLE
allow getOwnConfig (from embroider) access added definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ module.exports = {
     this.options["@embroider/macros"].setOwnConfig["types/date"] =
       defaults["types/date"] ??
       "ember-validated-form/components/validated-input/types/input";
+
+    Object.keys(defaults).map (key => {
+      this.options["@embroider/macros"].setOwnConfig[key] = defaults[key];
+    });      
   },
 
   options: {

--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ module.exports = {
       defaults["types/date"] ??
       "ember-validated-form/components/validated-input/types/input";
 
-    Object.keys(defaults).map (key => {
+    Object.keys(defaults).forEach((key) => {
       this.options["@embroider/macros"].setOwnConfig[key] = defaults[key];
-    });      
+    });
   },
 
   options: {


### PR DESCRIPTION
I went an gone with it. I need this to be able to add new custom components types

let me know if you require changes on this... (perhaps there is a better way)

see #912 